### PR TITLE
Add endpoint to retract reservations

### DIFF
--- a/.idea/libraries/Leiningen__net_clojars_macielti_common_test_clj_1_1_0.xml
+++ b/.idea/libraries/Leiningen__net_clojars_macielti_common_test_clj_1_1_0.xml
@@ -1,9 +1,0 @@
-<component name="libraryTable">
-  <library name="Leiningen: net.clojars.macielti/common-test-clj:1.1.0">
-    <CLASSES>
-      <root url="jar://$MAVEN_REPOSITORY$/net/clojars/macielti/common-test-clj/1.1.0/common-test-clj-1.1.0.jar!/" />
-    </CLASSES>
-    <JAVADOC />
-    <SOURCES />
-  </library>
-</component>

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
 
                    :test-paths     ["test/unit" "test/integration" "test/helpers"]
 
-                   :dependencies   [[net.clojars.macielti/common-test-clj "1.1.0"]
+                   :dependencies   [[net.clojars.macielti/common-test-clj "1.1.1"]
                                     [danlentz/clj-uuid "0.1.9"]
                                     [hashp "0.2.2"]
                                     [nubank/matcher-combinators "3.9.1"]

--- a/src/rango_graalvm/components.clj
+++ b/src/rango_graalvm/components.clj
@@ -3,6 +3,7 @@
             [common-clj.integrant-components.config :as component.config]
             [common-clj.integrant-components.prometheus :as component.prometheus]
             [common-clj.integrant-components.routes :as component.routes]
+            [common-test-clj.component.postgresql-mock :as component.postgresql-mock]
             [http-client-component.core :as component.http-client]
             [integrant.core :as ig]
             [new-relic-component.core :as component.new-relic]
@@ -41,5 +42,9 @@
 
 (def config-test
   (-> config
-      (assoc ::component.config/config {:path "resources/config.example.edn"
-                                        :env  :test})))
+      (dissoc ::component.postgresql/postgresql)
+      (merge {::component.config/config                   {:path "resources/config.example.edn"
+                                                           :env  :test}
+              ::component.postgresql-mock/postgresql-mock {:components {:config (ig/ref ::component.config/config)}}})
+      (assoc-in [::component.service/service :components :postgresql] (ig/ref ::component.postgresql-mock/postgresql-mock))
+      (assoc-in [::porteiro.admin/admin :components :postgresql] (ig/ref ::component.postgresql-mock/postgresql-mock))))

--- a/src/rango_graalvm/controllers/reservation.clj
+++ b/src/rango_graalvm/controllers/reservation.clj
@@ -18,6 +18,12 @@
         reservation
         (database.reservation/insert! (logic.reservation/->reservation student menu) database-conn)))))
 
+(s/defn retract!
+  [reservation-id :- s/Uuid
+   postgresql]
+  (pool/with-connection [database-conn postgresql]
+    (database.reservation/retract! reservation-id database-conn)))
+
 (s/defn fetch-by-menu :- [models.reservation/Reservation]
   [menu-id :- s/Uuid
    postgresql]

--- a/src/rango_graalvm/db/postgresql/reservation.clj
+++ b/src/rango_graalvm/db/postgresql/reservation.clj
@@ -31,3 +31,10 @@
                       {:params [menu-id student-id]})
           first
           adapters.reservation/postgresql->internal))
+
+(s/defn retract!
+  [reservation-id :- s/Uuid
+   database-conn]
+  (pg/execute database-conn
+              "DELETE FROM reservations WHERE id = $1"
+              {:params [reservation-id]}))

--- a/src/rango_graalvm/diplomat/http_server.clj
+++ b/src/rango_graalvm/diplomat/http_server.clj
@@ -54,6 +54,10 @@
               :post [(common-traceability/http-with-correlation-id diplomat.http-server.reservation/create-reservation!)]
               :route-name :create-reservation]
 
+             ["/api/reservations/:reservation-id"
+              :delete [(common-traceability/http-with-correlation-id diplomat.http-server.reservation/retract-reservation!)]
+              :route-name :retract-reservation]
+
              ["/api/reservations/menus/:menu-id"
               :get [interceptors.menu/menu-resource-existence-interceptor-check
                     (common-traceability/http-with-correlation-id diplomat.http-server.reservation/fetch-reservations-by-menu)]

--- a/src/rango_graalvm/diplomat/http_server.clj
+++ b/src/rango_graalvm/diplomat/http_server.clj
@@ -5,6 +5,7 @@
             [rango-graalvm.diplomat.http-server.reservation :as diplomat.http-server.reservation]
             [rango-graalvm.diplomat.http-server.student :as diplomat.http-server.student]
             [rango-graalvm.interceptors.menu :as interceptors.menu]
+            [rango-graalvm.interceptors.reservation :as interceptors.reservation]
             [rango-graalvm.interceptors.student :as interceptors.student]))
 
 (def routes [["/api/students"
@@ -55,7 +56,8 @@
               :route-name :create-reservation]
 
              ["/api/reservations/:reservation-id"
-              :delete [(common-traceability/http-with-correlation-id diplomat.http-server.reservation/retract-reservation!)]
+              :delete [interceptors.reservation/reservation-resource-existence-interceptor-check
+                       (common-traceability/http-with-correlation-id diplomat.http-server.reservation/retract-reservation!)]
               :route-name :retract-reservation]
 
              ["/api/reservations/menus/:menu-id"

--- a/src/rango_graalvm/diplomat/http_server/reservation.clj
+++ b/src/rango_graalvm/diplomat/http_server/reservation.clj
@@ -18,3 +18,10 @@
   {:status 200
    :body   {:reservations (->> (controllers.reservation/fetch-by-menu (UUID/fromString menu-id) postgresql)
                                (map adapters.reservation/internal->wire))}})
+
+(s/defn retract-reservation!
+  [{{:keys [reservation-id]} :path-params
+    {:keys [postgresql]}     :components}]
+  (controllers.reservation/retract! (UUID/fromString reservation-id) postgresql)
+  {:status 200
+   :body   {}})

--- a/src/rango_graalvm/interceptors/reservation.clj
+++ b/src/rango_graalvm/interceptors/reservation.clj
@@ -1,0 +1,11 @@
+(ns rango-graalvm.interceptors.reservation
+  (:require [postgresql-component.interceptors :as interceptors.postgresql])
+  (:import (java.util UUID)))
+
+(defn reservation-resource-identifier-fn
+  [{{:keys [path-params]} :request}]
+  (-> path-params :reservation-id UUID/fromString))
+
+(def reservation-resource-existence-interceptor-check
+  (interceptors.postgresql/resource-existence-check-interceptor reservation-resource-identifier-fn
+                                                                "SELECT * FROM reservations WHERE id = $1"))

--- a/test/helpers/fixtures/reservation.clj
+++ b/test/helpers/fixtures/reservation.clj
@@ -6,8 +6,11 @@
             [rango-graalvm.wire.postgresql.reservation :as wire.postgresql.reservation]
             [schema.core :as s]))
 
+(def reservation-id (random-uuid))
+
 (s/def reservation :- models.reservation/Reservation
-  (helpers.schema/generate models.reservation/Reservation {:reservation/menu-id fixtures.menu/menu-id
+  (helpers.schema/generate models.reservation/Reservation {:reservation/id         reservation-id
+                                                           :reservation/menu-id    fixtures.menu/menu-id
                                                            :reservation/student-id fixtures.student/student-id}))
 
 (s/def postgresql-reservation :- wire.postgresql.reservation/Reservation

--- a/test/integration/aux/http.clj
+++ b/test/integration/aux/http.clj
@@ -1,0 +1,55 @@
+(ns aux.http
+  (:require [cheshire.core :as json]
+            [io.pedestal.test :as test]))
+
+(defn authenticate-admin
+  [credentials
+   service-fn]
+  (let [{:keys [body status]} (test/response-for service-fn
+                                                 :post "/api/customers/auth"
+                                                 :headers {"Content-Type" "application/json"}
+                                                 :body (json/encode credentials))]
+    {:status status
+     :body   (json/decode body true)}))
+
+(defn create-student
+  [student
+   token
+   service-fn]
+  (let [{:keys [body status]} (test/response-for service-fn
+                                                 :post "/api/students"
+                                                 :headers {"Content-Type"  "application/json"
+                                                           "Authorization" (str "Bearer " token)}
+                                                 :body (json/encode student))]
+    {:status status
+     :body   (json/decode body true)}))
+
+(defn create-menu
+  [menu
+   token
+   service-fn]
+  (let [{:keys [body status]} (test/response-for service-fn
+                                                 :post "/api/menus"
+                                                 :headers {"Content-Type"  "application/json"
+                                                           "Authorization" (str "Bearer " token)}
+                                                 :body (json/encode menu))]
+    {:status status
+     :body   (json/decode body true)}))
+
+(defn create-reservation
+  [reservation
+   service-fn]
+  (let [{:keys [body status]} (test/response-for service-fn
+                                                 :post "/api/reservations"
+                                                 :headers {"Content-Type" "application/json"}
+                                                 :body (json/encode reservation))]
+    {:status status
+     :body   (json/decode body true)}))
+
+(defn retract-reservation
+  [reservation-id
+   service-fn]
+  (let [{:keys [body status]} (test/response-for service-fn
+                                                 :delete (str "/api/reservations/" reservation-id))]
+    {:status status
+     :body   (json/decode body true)}))

--- a/test/integration/retract_reservation_test.clj
+++ b/test/integration/retract_reservation_test.clj
@@ -1,0 +1,49 @@
+(ns retract-reservation-test
+  (:require [aux.http :as http]
+            [clj-uuid]
+            [clojure.test :refer [is testing]]
+            [fixtures.menu]
+            [fixtures.student]
+            [integrant.core :as ig]
+            [rango-graalvm.components :as components]
+            [schema.test :as s]
+            [service-component.core :as component.service]))
+
+(s/deftest retract-reservation-test
+  (let [system (ig/init components/config-test)
+        service-fn (-> system ::component.service/service :io.pedestal.http/service-fn)
+        token (-> (http/authenticate-admin {:customer {:username "admin" :password "da3bf409"}} service-fn)
+                  :body :token)
+        {student-access-code :code} (-> {:student fixtures.student/wire-in-student}
+                                        (http/create-student token service-fn)
+                                        :body :student)
+        {menu-id :id} (-> (http/create-menu {:menu fixtures.menu/wire-in-menu} token service-fn) :body :menu)
+        {reservation-id :id} (-> (http/create-reservation {:reservation {:student-code student-access-code
+                                                                         :menu-id      menu-id}} service-fn)
+                                 :body :reservation)]
+
+    (testing "Admin is authenticated"
+      (is (string? token)))
+
+    (testing "Student was created"
+      (is (string? student-access-code)))
+
+    (testing "Menu was created"
+      (is (clj-uuid/uuid-string? menu-id)))
+
+    (testing "Reservation was created"
+      (is (clj-uuid/uuid-string? reservation-id)))
+
+    (testing "Retract reservation"
+      (is (= {:status 200
+              :body   {}}
+             (http/retract-reservation reservation-id service-fn))))
+
+    (testing "Retract reservation that does not exist"
+      (is (= {:status 404
+              :body   {:detail  "Not Found"
+                       :error   "resource-not-found"
+                       :message "Resource could not be found"}}
+             (http/retract-reservation (random-uuid) service-fn))))
+
+    (ig/halt! system)))

--- a/test/unit/rango_graalvm/db/postgresql/reservation_test.clj
+++ b/test/unit/rango_graalvm/db/postgresql/reservation_test.clj
@@ -48,3 +48,15 @@
     (is (nil? (database.reservation/lookup-by-student-and-menu (random-uuid) fixtures.menu/menu-id conn)))
 
     (is (nil? (database.reservation/lookup-by-student-and-menu (random-uuid) (random-uuid) conn)))))
+
+(s/deftest retract-test
+  (let [conn (component.postgresql-mock/postgresql-conn-mock)]
+
+    (is (match? {:reservation/id         fixtures.reservation/reservation-id
+                 :reservation/student-id fixtures.student/student-id
+                 :reservation/menu-id    fixtures.menu/menu-id
+                 :reservation/created-at jt/local-date-time?}
+                (database.reservation/insert! fixtures.reservation/reservation conn)))
+
+    (is (match? {:deleted 1}
+                (database.reservation/retract! fixtures.reservation/reservation-id conn)))))


### PR DESCRIPTION
This pull request introduces several changes to add a new feature for retracting reservations in the `rango_graalvm` project. The changes span across multiple files, including the addition of new functions, routes, and tests. Here are the most important changes:

### New Feature: Retracting Reservations

* Added a new function `retract!` to the `reservation` controller to handle the retraction of reservations. (`src/rango_graalvm/controllers/reservation.clj`)
* Implemented the `retract!` function in the `reservation` database namespace to delete a reservation from the database. (`src/rango_graalvm/db/postgresql/reservation.clj`)
* Added a new route `/api/reservations/:reservation-id` for retracting reservations and the corresponding interceptor check for reservation existence. (`src/rango_graalvm/diplomat/http_server.clj`) [[1]](diffhunk://#diff-0e2a0e22c6e562fa9f2562473918ac3e4122ca157b92edc278311222e294fc2bR58-R62) [[2]](diffhunk://#diff-a9e1e08019a09b74db1547141624a8dea24efd2838976a14178bf977ce752988R1-R11)

### Dependency Updates

* Updated the dependency version of `common-test-clj` from `1.1.0` to `1.1.1` in `project.clj`. (`project.clj`)
* Removed the old library reference for `common-test-clj` version `1.1.0` from the IntelliJ IDEA project configuration. (`.idea/libraries/Leiningen__net_clojars_macielti_common_test_clj_1_1_0.xml`)

### Testing Enhancements

* Added integration tests for the retract reservation functionality, including tests for successful retraction and handling of non-existent reservations. (`test/integration/retract_reservation_test.clj`)
* Created helper functions in `aux.http` for common HTTP operations used in integration tests. (`test/integration/aux/http.clj`)
* Added unit tests for the `retract!` function in the `reservation` database namespace. (`test/unit/rango_graalvm/db/postgresql/reservation_test.clj`)

### Configuration Changes

* Updated the `config-test` configuration to use the new `postgresql-mock` component for testing purposes. (`src/rango_graalvm/components.clj`)

These changes collectively enhance the functionality of the `rango_graalvm` project by allowing reservations to be retracted and ensuring this new feature is well-tested and integrated.