### PR TITLE
Add fetch one Menu endpoint

### DIFF
--- a/src/rango_graalvm/controllers/menu.clj
+++ b/src/rango_graalvm/controllers/menu.clj
@@ -10,6 +10,12 @@
   (pool/with-connection [database-conn postgresql]
     (database.menu/insert! menu database-conn)))
 
+(s/defn fetch-one :- models.menu/Menu
+  [menu-id :- s/Uuid
+   postgresql]
+  (pool/with-connection [database-conn postgresql]
+    (database.menu/lookup menu-id database-conn)))
+
 (s/defn fetch-all :- [models.menu/Menu]
   [postgresql]
   (pool/with-connection [database-conn postgresql]

--- a/src/rango_graalvm/diplomat/http_server.clj
+++ b/src/rango_graalvm/diplomat/http_server.clj
@@ -47,6 +47,10 @@
                        (common-traceability/http-with-correlation-id diplomat.http-server.menu/retract-menu!)]
               :route-name :retract-menu]
 
+             ["/api/menus/:menu-id"
+              :get [(common-traceability/http-with-correlation-id diplomat.http-server.menu/fetch-one)]
+              :route-name :fetch-one-menu]
+
              ["/api/menus"
               :get [(common-traceability/http-with-correlation-id diplomat.http-server.menu/fetch-all)]
               :route-name :fetch-all-menus]

--- a/src/rango_graalvm/diplomat/http_server/menu.clj
+++ b/src/rango_graalvm/diplomat/http_server/menu.clj
@@ -12,6 +12,13 @@
                       (controllers.menu/create! postgresql)
                       adapters.menu/internal->wire)}})
 
+(s/defn fetch-one
+  [{{:keys [menu-id]}    :path-params
+    {:keys [postgresql]} :components}]
+  {:status 200
+   :body   {:menu (->> (controllers.menu/fetch-one (UUID/fromString menu-id) postgresql)
+                       adapters.menu/internal->wire)}})
+
 (s/defn fetch-all
   [{{:keys [postgresql]} :components}]
   {:status 200

--- a/test/integration/aux/components.clj
+++ b/test/integration/aux/components.clj
@@ -1,11 +1,11 @@
 (ns aux.components
-  (:require [rango-graalvm.components :as components]
+  (:require [common-clj.integrant-components.config :as component.config]
             [common-test-clj.component.postgresql-mock :as component.postgresql-mock]
-            [common-clj.integrant-components.config :as component.config]
-            [postgresql-component.core :as component.postgresql]
+            [integrant.core :as ig]
             [porteiro-component.admin-component :as porteiro.admin]
-            [service-component.core :as component.service]
-            [integrant.core :as ig]))
+            [postgresql-component.core :as component.postgresql]
+            [rango-graalvm.components :as components]
+            [service-component.core :as component.service]))
 
 (def config-test
   (-> components/config

--- a/test/integration/aux/http.clj
+++ b/test/integration/aux/http.clj
@@ -36,6 +36,15 @@
     {:status status
      :body   (json/decode body true)}))
 
+(defn fetch-one-menu
+  [menu-id
+   service-fn]
+  (let [{:keys [body status]} (test/response-for service-fn
+                                                 :get (str "/api/menus/" menu-id)
+                                                 :headers {"Content-Type" "application/json"})]
+    {:status status
+     :body   (json/decode body true)}))
+
 (defn create-reservation
   [reservation
    service-fn]

--- a/test/integration/fetch_one_menu_test.clj
+++ b/test/integration/fetch_one_menu_test.clj
@@ -1,0 +1,30 @@
+(ns fetch-one-menu-test
+  (:require [aux.components :as components]
+            [aux.http :as http]
+            [clj-uuid]
+            [clojure.test :refer [is testing]]
+            [fixtures.menu]
+            [integrant.core :as ig]
+            [matcher-combinators.test :refer [match?]]
+            [schema.test :as s]
+            [service-component.core :as component.service]))
+
+(s/deftest fetch-one-menu-test
+  (let [system (ig/init components/config-test)
+        service-fn (-> system ::component.service/service :io.pedestal.http/service-fn)
+        token (-> (http/authenticate-admin {:customer {:username "admin" :password "da3bf409"}} service-fn)
+                  :body :token)
+        {menu-id :id} (-> (http/create-menu {:menu fixtures.menu/wire-in-menu} token service-fn) :body :menu)]
+
+    (testing "Admin is authenticated"
+      (is (string? token)))
+
+    (testing "Menu was created"
+      (is (clj-uuid/uuid-string? menu-id)))
+
+    (testing "Fetch one menu"
+      (is (match? {:status 200
+                   :body   {:menu {:id clj-uuid/uuid-string?}}}
+                  (http/fetch-one-menu menu-id service-fn))))
+
+    (ig/halt! system)))

--- a/test/integration/retract_reservation_test.clj
+++ b/test/integration/retract_reservation_test.clj
@@ -1,6 +1,6 @@
 (ns retract-reservation-test
-  (:require [aux.http :as http]
-            [aux.components :as components]
+  (:require [aux.components :as components]
+            [aux.http :as http]
             [clj-uuid]
             [clojure.test :refer [is testing]]
             [fixtures.menu]


### PR DESCRIPTION
This pull request introduces a new feature to fetch a single menu by its ID and includes several associated changes across different files. The changes add a new endpoint to the HTTP server, implement the necessary controller function, and include corresponding tests for the new functionality.

### New feature: Fetch a single menu by ID

* [`src/rango_graalvm/controllers/menu.clj`](diffhunk://#diff-dcfb1c5e984fdd1394a33a5e22873ea6d25921fe91951e129b514ca158ff9a32R13-R18): Added `fetch-one` function to retrieve a single menu by its ID.
* [`src/rango_graalvm/diplomat/http_server.clj`](diffhunk://#diff-0e2a0e22c6e562fa9f2562473918ac3e4122ca157b92edc278311222e294fc2bR50-R53): Added a new route `/api/menus/:menu-id` to handle GET requests for fetching a single menu.
* [`src/rango_graalvm/diplomat/http_server/menu.clj`](diffhunk://#diff-d0905d22418ed847e10d3829cffbbd68e6d6fe75b215e824b5e1df8a8df9a11bR15-R21): Implemented the `fetch-one` function to handle the new HTTP route and return the menu details.

### Testing

* [`test/integration/aux/http.clj`](diffhunk://#diff-69baacae36e6b9be9f3bcf4ee40346d5ab1e5adabeb086dbb69d6a849c60009aR39-R47): Added `fetch-one-menu` function to facilitate testing of the new endpoint.
* [`test/integration/fetch_one_menu_test.clj`](diffhunk://#diff-a98e61d3add69f5bcee99383312c7a2d0174047271fba3f1eae6dad06e5a6172R1-R30): Created a new test file to verify the functionality of fetching a single menu by ID.

### Code organization

* [`test/integration/aux/components.clj`](diffhunk://#diff-351fc7183fd468a466ceb57b956e51e38413fcc8184f9cf88e127847c87b7d85L2-R8): Reorganized the import statements for better clarity and maintainability.
* [`test/integration/retract_reservation_test.clj`](diffhunk://#diff-15c900ace79d534ce364f363442600c238ce84c8e944422f37fd4c9313b47ee7L2-R3): Adjusted import order for consistency.