### PR TITLE
Fetch Reservation by Student and Menu

### DIFF
--- a/src/rango_graalvm/controllers/reservation.clj
+++ b/src/rango_graalvm/controllers/reservation.clj
@@ -29,3 +29,12 @@
    postgresql]
   (pool/with-connection [database-conn postgresql]
     (database.reservation/by-menu menu-id database-conn)))
+
+(s/defn fetch-student-reservation-by-menu :- models.reservation/Reservation
+  [student-code :- s/Str
+   menu-id :- s/Uuid
+   postgresql]
+  (pool/with-connection [database-conn postgresql]
+    (-> (database.student/lookup-by-code student-code database-conn)
+        :student/id
+        (database.reservation/fetch-student-reservation-by-menu menu-id database-conn))))

--- a/src/rango_graalvm/db/postgresql/reservation.clj
+++ b/src/rango_graalvm/db/postgresql/reservation.clj
@@ -38,3 +38,16 @@
   (pg/execute database-conn
               "DELETE FROM reservations WHERE id = $1"
               {:params [reservation-id]}))
+
+(s/defn fetch-student-reservation-by-menu :- (s/maybe models.reservation/Reservation)
+  [student-id :- s/Uuid
+   menu-id :- s/Uuid
+   database-conn]
+  (some-> (pg/execute database-conn
+                      "SELECT *
+                       FROM reservations
+                       WHERE
+                         menu_id = $1 AND student_id = $2"
+                      {:params [menu-id student-id]})
+          first
+          adapters.reservation/postgresql->internal))

--- a/src/rango_graalvm/diplomat/http_server.clj
+++ b/src/rango_graalvm/diplomat/http_server.clj
@@ -59,10 +59,9 @@
               :post [(common-traceability/http-with-correlation-id diplomat.http-server.reservation/create-reservation!)]
               :route-name :create-reservation]
 
-             ["/api/reservations/students/:student-code/menus/:menu-id"
-              :get [interceptors.menu/menu-resource-existence-interceptor-check
-                    (common-traceability/http-with-correlation-id diplomat.http-server.reservation/fetch-student-reservation-by-menu)]
-              :route-name :fetch-student-reservation-by-menu]
+             ["/api/reservation-by-student-and-menu"
+              :get [(common-traceability/http-with-correlation-id diplomat.http-server.reservation/fetch-student-reservation-by-menu)]
+              :route-name :fetch-reservation-by-student-and-menu]
 
              ["/api/reservations/:reservation-id"
               :delete [interceptors.reservation/reservation-resource-existence-interceptor-check

--- a/src/rango_graalvm/diplomat/http_server.clj
+++ b/src/rango_graalvm/diplomat/http_server.clj
@@ -59,6 +59,11 @@
               :post [(common-traceability/http-with-correlation-id diplomat.http-server.reservation/create-reservation!)]
               :route-name :create-reservation]
 
+             ["/api/reservations/students/:student-code/menus/:menu-id"
+              :get [interceptors.menu/menu-resource-existence-interceptor-check
+                    (common-traceability/http-with-correlation-id diplomat.http-server.reservation/fetch-student-reservation-by-menu)]
+              :route-name :fetch-student-reservation-by-menu]
+
              ["/api/reservations/:reservation-id"
               :delete [interceptors.reservation/reservation-resource-existence-interceptor-check
                        (common-traceability/http-with-correlation-id diplomat.http-server.reservation/retract-reservation!)]

--- a/src/rango_graalvm/diplomat/http_server/reservation.clj
+++ b/src/rango_graalvm/diplomat/http_server/reservation.clj
@@ -25,3 +25,12 @@
   (controllers.reservation/retract! (UUID/fromString reservation-id) postgresql)
   {:status 200
    :body   {}})
+
+(s/defn fetch-student-reservation-by-menu
+  [{{:keys [student-code menu-id]} :path-params
+    {:keys [postgresql]}           :components}]
+  {:status 200
+   :body   {:reservation (-> (controllers.reservation/fetch-student-reservation-by-menu student-code
+                                                                                        (UUID/fromString menu-id)
+                                                                                        postgresql)
+                             adapters.reservation/internal->wire)}})

--- a/src/rango_graalvm/diplomat/http_server/reservation.clj
+++ b/src/rango_graalvm/diplomat/http_server/reservation.clj
@@ -27,7 +27,7 @@
    :body   {}})
 
 (s/defn fetch-student-reservation-by-menu
-  [{{:keys [student-code menu-id]} :path-params
+  [{{:keys [student-code menu-id]} :query-params
     {:keys [postgresql]}           :components}]
   {:status 200
    :body   {:reservation (-> (controllers.reservation/fetch-student-reservation-by-menu student-code

--- a/test/integration/aux/http.clj
+++ b/test/integration/aux/http.clj
@@ -68,6 +68,6 @@
    menu-id
    service-fn]
   (let [{:keys [body status]} (test/response-for service-fn
-                                                 :get (str "/api/reservations-by-student-and-menu?student-code=" student-code "&menu-id=" menu-id))]
+                                                 :get (str "/api/reservation-by-student-and-menu?student-code=" student-code "&menu-id=" menu-id))]
     {:status status
      :body   (json/decode body true)}))

--- a/test/integration/aux/http.clj
+++ b/test/integration/aux/http.clj
@@ -62,3 +62,12 @@
                                                  :delete (str "/api/reservations/" reservation-id))]
     {:status status
      :body   (json/decode body true)}))
+
+(defn fetch-student-reservation-by-menu
+  [student-code
+   menu-id
+   service-fn]
+  (let [{:keys [body status]} (test/response-for service-fn
+                                                 :get (str "/api/reservations/students/" student-code "/menus/" menu-id))]
+    {:status status
+     :body   (json/decode body true)}))

--- a/test/integration/aux/http.clj
+++ b/test/integration/aux/http.clj
@@ -68,6 +68,6 @@
    menu-id
    service-fn]
   (let [{:keys [body status]} (test/response-for service-fn
-                                                 :get (str "/api/reservations/students/" student-code "/menus/" menu-id))]
+                                                 :get (str "/api/reservations-by-student-and-menu?student-code=" student-code "&menu-id=" menu-id))]
     {:status status
      :body   (json/decode body true)}))

--- a/test/integration/reservation_test.clj
+++ b/test/integration/reservation_test.clj
@@ -6,6 +6,7 @@
             [fixtures.menu]
             [fixtures.student]
             [integrant.core :as ig]
+            [matcher-combinators.test :refer [match?]]
             [schema.test :as s]
             [service-component.core :as component.service]))
 
@@ -74,8 +75,9 @@
       (is (clj-uuid/uuid-string? reservation-id)))
 
     (testing "Retract reservation"
-      (is (= {:status 200
-              :body   {}}
-             (http/fetch-student-reservation-by-menu student-access-code menu-id service-fn))))
+      (is (match? {:status 200
+                   :body   {:reservation {:id      clj-uuid/uuid-string?
+                                          :menu-id menu-id}}}
+                  (http/fetch-student-reservation-by-menu student-access-code menu-id service-fn))))
 
     (ig/halt! system)))

--- a/test/integration/reservation_test.clj
+++ b/test/integration/reservation_test.clj
@@ -1,4 +1,4 @@
-(ns retract-reservation-test
+(ns reservation-test
   (:require [aux.components :as components]
             [aux.http :as http]
             [clj-uuid]
@@ -45,5 +45,37 @@
                        :error   "resource-not-found"
                        :message "Resource could not be found"}}
              (http/retract-reservation (random-uuid) service-fn))))
+
+    (ig/halt! system)))
+
+(s/deftest fetch-student-reservation-by-menu-test
+  (let [system (ig/init components/config-test)
+        service-fn (-> system ::component.service/service :io.pedestal.http/service-fn)
+        token (-> (http/authenticate-admin {:customer {:username "admin" :password "da3bf409"}} service-fn)
+                  :body :token)
+        {student-access-code :code} (-> {:student fixtures.student/wire-in-student}
+                                        (http/create-student token service-fn)
+                                        :body :student)
+        {menu-id :id} (-> (http/create-menu {:menu fixtures.menu/wire-in-menu} token service-fn) :body :menu)
+        {reservation-id :id} (-> (http/create-reservation {:reservation {:student-code student-access-code
+                                                                         :menu-id      menu-id}} service-fn)
+                                 :body :reservation)]
+
+    (testing "Admin is authenticated"
+      (is (string? token)))
+
+    (testing "Student was created"
+      (is (string? student-access-code)))
+
+    (testing "Menu was created"
+      (is (clj-uuid/uuid-string? menu-id)))
+
+    (testing "Reservation was created"
+      (is (clj-uuid/uuid-string? reservation-id)))
+
+    (testing "Retract reservation"
+      (is (= {:status 200
+              :body   {}}
+             (http/fetch-student-reservation-by-menu student-access-code menu-id service-fn))))
 
     (ig/halt! system)))


### PR DESCRIPTION
This pull request introduces a new feature to fetch a student's reservation by menu ID, along with related test cases and HTTP endpoints. Here are the most important changes:

### New Functionality:
* Added `fetch-student-reservation-by-menu` function in `src/rango_graalvm/controllers/reservation.clj` to handle fetching reservations by student code and menu ID.
* Added `fetch-student-reservation-by-menu` function in `src/rango_graalvm/db/postgresql/reservation.clj` to query the database for reservations by student ID and menu ID.

### HTTP Endpoints:
* Added a new API endpoint `/api/reservation-by-student-and-menu` in `src/rango_graalvm/diplomat/http_server.clj` to handle HTTP GET requests for fetching reservations by student and menu.
* Implemented the controller function for the new endpoint in `src/rango_graalvm/diplomat/http_server/reservation.clj`.

### Testing:
* Added a new test function `fetch-student-reservation-by-menu-test` in `test/integration/reservation_test.clj` to test the new functionality.
* Added a helper function `fetch-student-reservation-by-menu` in `test/integration/aux/http.clj` to facilitate the testing process.
* Renamed `test/integration/retract_reservation_test.clj` to `test/integration/reservation_test.clj` to better reflect the expanded scope of the tests.