### PR TITLE
Add fetch one reservation endpoint

### DIFF
--- a/src/rango_graalvm/controllers/reservation.clj
+++ b/src/rango_graalvm/controllers/reservation.clj
@@ -30,6 +30,12 @@
   (pool/with-connection [database-conn postgresql]
     (database.reservation/by-menu menu-id database-conn)))
 
+(s/defn fetch-reservation :- models.reservation/Reservation
+  [reservation-id :- s/Uuid
+   postgresql]
+  (pool/with-connection [database-conn postgresql]
+    (database.reservation/lookup reservation-id database-conn)))
+
 (s/defn fetch-student-reservation-by-menu :- models.reservation/Reservation
   [student-code :- s/Str
    menu-id :- s/Uuid

--- a/src/rango_graalvm/db/postgresql/reservation.clj
+++ b/src/rango_graalvm/db/postgresql/reservation.clj
@@ -22,6 +22,15 @@
                       {:params [menu-id]})
           (->> (map adapters.reservation/postgresql->internal))))
 
+(s/defn lookup :- (s/maybe models.reservation/Reservation)
+  [reservation-id :- s/Uuid
+   database-conn]
+  (some-> (pg/execute database-conn
+                      "SELECT * FROM reservations WHERE id = $1"
+                      {:params [reservation-id]})
+          first
+          adapters.reservation/postgresql->internal))
+
 (s/defn lookup-by-student-and-menu :- (s/maybe models.reservation/Reservation)
   [student-id :- s/Uuid
    menu-id :- s/Uuid

--- a/src/rango_graalvm/diplomat/http_server.clj
+++ b/src/rango_graalvm/diplomat/http_server.clj
@@ -68,6 +68,11 @@
                        (common-traceability/http-with-correlation-id diplomat.http-server.reservation/retract-reservation!)]
               :route-name :retract-reservation]
 
+             ["/api/reservations/:reservation-id"
+              :get [interceptors.reservation/reservation-resource-existence-interceptor-check
+                    (common-traceability/http-with-correlation-id diplomat.http-server.reservation/fetch-reservation)]
+              :route-name :fetch-one-reservation]
+
              ["/api/reservations/menus/:menu-id"
               :get [interceptors.menu/menu-resource-existence-interceptor-check
                     (common-traceability/http-with-correlation-id diplomat.http-server.reservation/fetch-reservations-by-menu)]

--- a/src/rango_graalvm/diplomat/http_server/reservation.clj
+++ b/src/rango_graalvm/diplomat/http_server/reservation.clj
@@ -19,6 +19,13 @@
    :body   {:reservations (->> (controllers.reservation/fetch-by-menu (UUID/fromString menu-id) postgresql)
                                (map adapters.reservation/internal->wire))}})
 
+(s/defn fetch-reservation
+  [{{:keys [reservation-id]} :path-params
+    {:keys [postgresql]}     :components}]
+  {:status 200
+   :body   {:reservation (->> (controllers.reservation/fetch-reservation (UUID/fromString reservation-id) postgresql)
+                              adapters.reservation/internal->wire)}})
+
 (s/defn retract-reservation!
   [{{:keys [reservation-id]} :path-params
     {:keys [postgresql]}     :components}]

--- a/test/integration/aux/http.clj
+++ b/test/integration/aux/http.clj
@@ -71,3 +71,11 @@
                                                  :get (str "/api/reservation-by-student-and-menu?student-code=" student-code "&menu-id=" menu-id))]
     {:status status
      :body   (json/decode body true)}))
+
+(defn fetch-one-reservation
+  [reservation-id
+   service-fn]
+  (let [{:keys [body status]} (test/response-for service-fn
+                                                 :get (str "/api/reservations/" reservation-id))]
+    {:status status
+     :body   (json/decode body true)}))

--- a/test/integration/reservation_test.clj
+++ b/test/integration/reservation_test.clj
@@ -82,7 +82,6 @@
 
     (ig/halt! system)))
 
-
 (s/deftest fetch-one-reservation-test
   (let [system (ig/init components/config-test)
         service-fn (-> system ::component.service/service :io.pedestal.http/service-fn)

--- a/test/integration/reservation_test.clj
+++ b/test/integration/reservation_test.clj
@@ -74,10 +74,44 @@
     (testing "Reservation was created"
       (is (clj-uuid/uuid-string? reservation-id)))
 
-    (testing "Retract reservation"
+    (testing "Fetch reservation"
       (is (match? {:status 200
                    :body   {:reservation {:id      clj-uuid/uuid-string?
                                           :menu-id menu-id}}}
                   (http/fetch-student-reservation-by-menu student-access-code menu-id service-fn))))
+
+    (ig/halt! system)))
+
+
+(s/deftest fetch-one-reservation-test
+  (let [system (ig/init components/config-test)
+        service-fn (-> system ::component.service/service :io.pedestal.http/service-fn)
+        token (-> (http/authenticate-admin {:customer {:username "admin" :password "da3bf409"}} service-fn)
+                  :body :token)
+        {student-access-code :code} (-> {:student fixtures.student/wire-in-student}
+                                        (http/create-student token service-fn)
+                                        :body :student)
+        {menu-id :id} (-> (http/create-menu {:menu fixtures.menu/wire-in-menu} token service-fn) :body :menu)
+        {reservation-id :id} (-> (http/create-reservation {:reservation {:student-code student-access-code
+                                                                         :menu-id      menu-id}} service-fn)
+                                 :body :reservation)]
+
+    (testing "Admin is authenticated"
+      (is (string? token)))
+
+    (testing "Student was created"
+      (is (string? student-access-code)))
+
+    (testing "Menu was created"
+      (is (clj-uuid/uuid-string? menu-id)))
+
+    (testing "Reservation was created"
+      (is (clj-uuid/uuid-string? reservation-id)))
+
+    (testing "Fetch one reservation"
+      (is (match? {:status 200
+                   :body   {:reservation {:id      clj-uuid/uuid-string?
+                                          :menu-id menu-id}}}
+                  (http/fetch-one-reservation reservation-id service-fn))))
 
     (ig/halt! system)))

--- a/test/unit/rango_graalvm/db/postgresql/reservation_test.clj
+++ b/test/unit/rango_graalvm/db/postgresql/reservation_test.clj
@@ -60,3 +60,12 @@
 
     (is (match? {:deleted 1}
                 (database.reservation/retract! fixtures.reservation/reservation-id conn)))))
+
+(s/deftest lookup-test
+  (let [conn (component.postgresql-mock/postgresql-conn-mock)]
+    (database.reservation/insert! fixtures.reservation/reservation conn)
+
+    (is (match? {:reservation/id fixtures.reservation/reservation-id}
+                (database.reservation/lookup fixtures.reservation/reservation-id conn)))
+
+    (is (nil? (database.reservation/lookup (random-uuid) conn)))))


### PR DESCRIPTION
This pull request introduces a new feature to fetch a single reservation by its ID. The changes include defining new functions, updating the HTTP server routes, and adding corresponding tests. The most important changes are summarized below:

### New Functionality:
* Added `fetch-reservation` function in `src/rango_graalvm/controllers/reservation.clj` to fetch a reservation by its ID.
* Added `lookup` function in `src/rango_graalvm/db/postgresql/reservation.clj` to query the database for a reservation by its ID.

### HTTP Server Updates:
* Added a new route `/api/reservations/:reservation-id` to fetch a single reservation in `src/rango_graalvm/diplomat/http_server.clj`.
* Defined `fetch-reservation` function in `src/rango_graalvm/diplomat/http_server/reservation.clj` to handle the new route.

### Testing:
* Added `fetch-one-reservation` function in `test/integration/aux/http.clj` to support integration testing of the new endpoint.
* Added a new test `fetch-one-reservation-test` in `test/integration/reservation_test.clj` to ensure the new functionality works correctly.